### PR TITLE
Add support for YUYV format image rendering

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -147,6 +147,7 @@ pub enum ShaderType {
     FilterImage,
     FillColor,
     TextureCopyUnclipped,
+    YuyvImage,
 }
 
 impl Default for ShaderType {
@@ -165,6 +166,7 @@ impl ShaderType {
             Self::FilterImage => 4,
             Self::FillColor => 5,
             Self::TextureCopyUnclipped => 6,
+            Self::YuyvImage => 7,
         }
     }
     pub fn to_f32(self) -> f32 {

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -39,9 +39,9 @@ pub struct OpenGl {
     view: [f32; 2],
     screen_view: [f32; 2],
     // All types of the vertex/fragment shader, indexed by shader_type when has_glyph_texture is true
-    main_programs_with_glyph_texture: [Option<MainProgram>; 7],
+    main_programs_with_glyph_texture: [Option<MainProgram>; 8],
     // Same shader programs but with has_glyph_texture being false
-    main_programs_without_glyph_texture: [Option<MainProgram>; 7],
+    main_programs_without_glyph_texture: [Option<MainProgram>; 8],
     current_program: u8,
     current_program_needs_glyph_texture: bool,
     vert_arr: Option<<glow::Context as glow::HasContext>::VertexArray>,
@@ -157,6 +157,12 @@ impl OpenGl {
                         false,
                     )?)
                 },
+                Some(MainProgram::new(
+                    &context,
+                    antialias,
+                    ShaderType::YuyvImage,
+                    with_glyph_texture,
+                )?),
             ])
         };
 

--- a/src/renderer/opengl/main-fs.glsl
+++ b/src/renderer/opengl/main-fs.glsl
@@ -79,39 +79,48 @@ vec4 renderImageGradient() {
     return texture2D(tex, vec2(d, 0.0));//mix(innerCol,outerCol,d);
 }
 
+// Converts YUYV (YUV422) format texture data to RGB color
+// TODO: Pick the correct current pixel
 vec4 renderYuyvImage() {
-    // Calculate color from texture
+    // Transform fragment position using paint matrix and normalize by extent
     vec2 pt = (paintMat * vec3(fpos, 1.0)).xy / (extent * 2.0);
+    
+    // Sample YUYV texture and scale to 0-255 range
+    // YUYV format packs 2 pixels into one texel: [Y0 U Y1 V]
     vec4 yuyv = texture2D(tex, pt) * 255.0;
+    
+    // Extract individual Y, U, V components
+    float y0 = yuyv.x;  // Y value for first pixel
+    float u  = yuyv.y;  // U (Cb) shared between two pixels
+    float y1 = yuyv.z;  // Y value for second pixel
+    float v  = yuyv.w;  // V (Cr) shared between two pixels
 
+    // Convert YUV to RGB for first pixel using standard conversion matrix
+    // Reference: BT.601/BT.709 color space conversion
+    float r0 = y0 + 1.370705 * (v - 128.);  // Red component 
+    float g0 = y0 - 0.698001 * (v - 128.) - 0.337633 * (u - 128.);  // Green component
+    float b0 = y0 + 1.732446 * (u - 128.);  // Blue component
 
-    float y0= yuyv.x;
-    float u = yuyv.y;
-    float y1= yuyv.z;
-    float v = yuyv.w;
-
-    float r0 = y0 + 1.370705 * (v - 128.);
-    float g0 = y0 - 0.698001 * (v - 128.) - 0.337633 * (u - 128.);
-    float b0 = y0 + 1.732446 * (u - 128.);
-
+    // Convert YUV to RGB for second pixel
     float r1 = y1 + 1.370705 * (v - 128.);
     float g1 = y1 - 0.698001 * (v - 128.) - 0.337633 * (u - 128.);
     float b1 = y1 + 1.732446 * (u - 128.);
 
-    // if (mod(pt.x * viewSize.x, 2.0) < 1.0) {
-    //     r0 = r1;
-    //     g0 = g1;
-    //     b0 = b1;
-    // }
-
+    // Use first pixel's RGB values for output color
     vec4 color = vec4(r0, g0, b0, 255.0);
+    
+    // Normalize color values back to 0-1 range
     color /= 255.0;
 
+    // Handle different texture types:
+    // texType == 1: Premultiplied alpha
+    // texType == 2: Single channel (grayscale)
     if (texType == 1) color = vec4(color.xyz * color.w, color.w);
     if (texType == 2) color = vec4(color.x);
 
-    // Apply color tint and alpha.
+    // Apply color tinting and alpha modification
     color *= innerCol;
+    
     return color;
 }
 

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -244,4 +244,8 @@ impl Params {
     pub(crate) fn uses_glyph_texture(self) -> bool {
         self.glyph_texture_type != 0
     }
+
+    pub(crate) fn use_yuyv_image_format(&mut self) {
+        self.shader_type = ShaderType::YuyvImage;
+    }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1102,7 +1102,13 @@ impl GlyphAtlas {
                             },
                         );
                     } else {
-                        canvas.fill_path_internal(path, &PaintFlavor::Color(mask_color), false, FillRule::EvenOdd);
+                        canvas.fill_path_internal(
+                            path,
+                            &PaintFlavor::Color(mask_color),
+                            false,
+                            FillRule::EvenOdd,
+                            false,
+                        );
                     }
 
                     canvas.restore();
@@ -1291,7 +1297,7 @@ pub(crate) fn render_direct<T: Renderer>(
                         },
                     );
                 } else {
-                    canvas.fill_path_internal(path.borrow(), paint_flavor, anti_alias, FillRule::EvenOdd);
+                    canvas.fill_path_internal(path.borrow(), paint_flavor, anti_alias, FillRule::EvenOdd, false);
                 }
             }
             #[cfg(feature = "image-loading")]


### PR DESCRIPTION
Added support for rendering images in YUYV (YUY2) format, a common format used in video capture devices and webcams. YUYV is a packed pixel format where each 4 bytes represents 2 pixels using YUV color encoding.

- Implemented a shader function to render YUYV images.
- Added a shader type `ShaderType::YuyvImage` and it's respective shader program.
- Calling the function `canvas.fill_path_yuyv(&path, &paint)` will render using the format.